### PR TITLE
Yewprint upgrade 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,18 +82,24 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.48"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e1f47f7dc0422027a4e370dd4548d4d66b26782e513e98dca1e689e058a80e"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+
+[[package]]
+name = "anymap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
 name = "arrayref"
@@ -299,9 +305,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.51"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -558,6 +564,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8100e46ff92eb85bf6dc2930c73f2a4f7176393c84a9446b3d501e1b354e7b34"
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -676,9 +688,9 @@ checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -796,9 +808,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.29"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -967,9 +979,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -982,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -992,15 +1004,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1009,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-lite"
@@ -1030,10 +1042,12 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
+ "autocfg",
+ "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -1041,22 +1055,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.18"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1066,6 +1081,8 @@ dependencies = [
  "memchr",
  "pin-project-lite 0.2.7",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab",
 ]
 
@@ -1119,6 +1136,18 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "gloo"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ce6f2dfa9f57f15b848efa2aade5e1850dc72986b87a2b0752d44ca08f4967"
+dependencies = [
+ "gloo-console-timer",
+ "gloo-events",
+ "gloo-file 0.1.0",
+ "gloo-timers",
+]
+
+[[package]]
+name = "gloo"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23947965eee55e3e97a5cd142dd4c10631cc349b48cecca0ed230fd296f568cd"
@@ -1126,7 +1155,7 @@ dependencies = [
  "gloo-console",
  "gloo-dialogs",
  "gloo-events",
- "gloo-file",
+ "gloo-file 0.2.0",
  "gloo-render",
  "gloo-storage",
  "gloo-timers",
@@ -1146,6 +1175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-console-timer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48675544b29ac03402c6dffc31a912f716e38d19f7e74b78b7e900ec3c941ea"
+dependencies = [
+ "web-sys",
+]
+
+[[package]]
 name = "gloo-dialogs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1199,18 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "088514ec8ef284891c762c88a66b639b3a730134714692ee31829765c5bc814f"
 dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-file"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9fecfe46b5dc3cc46f58e98ba580cc714f2c93860796d002eb3527a465ef49"
+dependencies = [
+ "gloo-events",
+ "js-sys",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1229,9 +1279,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
 dependencies = [
  "bytes",
  "fnv",
@@ -1314,7 +1364,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1383,9 +1433,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.15"
+version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1396,7 +1446,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 0.4.8",
  "pin-project-lite 0.2.7",
  "socket2",
  "tokio",
@@ -1520,6 +1570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,9 +1623,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libz-sys"
@@ -1802,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "onig"
@@ -1856,9 +1912,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.71"
+version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
  "autocfg",
  "cc",
@@ -1928,9 +1984,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "platforms"
@@ -2013,10 +2069,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.32"
+name = "proc-macro-nested"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]
@@ -2165,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
+checksum = "07bea77bc708afa10e59905c3d4af7c8fd43c9214251673095ff8b14345fcbc5"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -2249,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "safe-lock"
@@ -2396,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
 dependencies = [
  "serde_derive",
 ]
@@ -2417,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2428,11 +2490,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.71"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -2455,7 +2517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -2481,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+checksum = "c35dfd12afb7828318348b8c408383cf5071a086c1d4ab1c0f9840ec92dbb922"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2631,9 +2693,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2676,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
 dependencies = [
  "filetime",
  "libc",
@@ -2792,7 +2854,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "libc",
 ]
 
@@ -2836,11 +2898,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -3443,12 +3504,40 @@ dependencies = [
 
 [[package]]
 name = "yew"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d5154faef86dddd2eb333d4755ea5643787d20aca683e58759b0e53351409f"
+dependencies = [
+ "anyhow",
+ "anymap",
+ "bincode",
+ "cfg-if 1.0.0",
+ "cfg-match",
+ "console_error_panic_hook",
+ "gloo 0.2.1",
+ "http",
+ "indexmap",
+ "js-sys",
+ "log",
+ "ryu",
+ "serde",
+ "serde_json",
+ "slab",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yew-macro 0.18.0",
+]
+
+[[package]]
+name = "yew"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a1ccb53e57d3f7d847338cf5758befa811cabe207df07f543c06f502f9998cd"
 dependencies = [
  "console_error_panic_hook",
- "gloo",
+ "gloo 0.4.2",
  "gloo-utils",
  "indexmap",
  "js-sys",
@@ -3457,7 +3546,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "yew-macro",
+ "yew-macro 0.19.3",
+]
+
+[[package]]
+name = "yew-macro"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e23bfe3dc3933fbe9592d149c9985f3047d08c637a884b9344c21e56e092ef"
+dependencies = [
+ "boolinator",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3480,7 +3582,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "155804f6f3aa309f596d5c3fa14486a94e7756f1edd7634569949e401d5099f2"
 dependencies = [
- "gloo",
+ "gloo 0.4.2",
  "gloo-utils",
  "js-sys",
  "route-recognizer 0.3.1",
@@ -3490,7 +3592,7 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "web-sys",
- "yew",
+ "yew 0.19.3",
  "yew-router-macro",
 ]
 
@@ -3516,7 +3618,8 @@ dependencies = [
  "regex",
  "wasm-bindgen",
  "web-sys",
- "yew",
+ "yew 0.19.3",
+ "yewtil",
 ]
 
 [[package]]
@@ -3537,14 +3640,40 @@ version = "0.1.0"
 dependencies = [
  "build-data",
  "console_error_panic_hook",
+ "gloo-dialogs",
  "reqwest",
  "syntect",
  "wasm-bindgen",
  "web-sys",
  "wee_alloc",
- "yew",
+ "yew 0.19.3",
  "yew-router",
  "yewprint",
+]
+
+[[package]]
+name = "yewtil"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543663ac49cd613df079282a1d8bdbdebdad6e02bac229f870fd4237b5d9aaa"
+dependencies = [
+ "log",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yew 0.18.0",
+ "yewtil-macro",
+]
+
+[[package]]
+name = "yewtil-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1433d8554db0f0a87a38aeea190780c1d5f9570384d99a34ab4de1c51d8eb8f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/yewprint-doc/Cargo.toml
+++ b/yewprint-doc/Cargo.toml
@@ -15,6 +15,7 @@ yew = "0.19"
 web-sys = { version = "0.3", features = ["Window", "MediaQueryList"] }
 yewprint = { path = "../yewprint" }
 yew-router = "0.16"
+gloo-dialogs = "0.1.0"
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default

--- a/yewprint-doc/src/app.rs
+++ b/yewprint-doc/src/app.rs
@@ -22,24 +22,103 @@ use crate::tag::*;
 use crate::text::*;
 use crate::text_area::*;
 use crate::tree::*;
-use std::borrow::Cow;
+use yew_router::prelude::*;
 use yew::prelude::*;
-use yew_router::{
-    agent::{RouteAgentDispatcher, RouteRequest},
-    router::Router,
-    Switch,
-};
 use yewprint::{IconName, Menu, MenuItem};
 
 pub struct App {
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     dark_theme: bool,
-    route_dispatcher: RouteAgentDispatcher,
+    active: Option<DocMenu>,
 }
 
 pub enum Msg {
     ToggleLight,
     GoToMenu(DocMenu),
+}
+
+#[derive(Clone, PartialEq, Routable)]
+pub enum DocMenu {
+    #[at("/button-group")]
+    ButtonGroup,
+    #[at("/button")]
+    Button,
+    #[at("/callout")]
+    Callout,
+    #[at("/card")]
+    Card,
+    #[at("/checkbox")]
+    Checkbox,
+    #[at("/collapse")]
+    Collapse,
+    #[at("/control-group")]
+    ControlGroup,
+    #[at("/html-select")]
+    HtmlSelect,
+    #[at("/divider")]
+    Divider,
+    #[at("/icon")]
+    Icon,
+    #[at("/input-group")]
+    InputGroup,
+    #[at("/menu")]
+    Menu,
+    #[at("/numeric-input")]
+    NumericInput,
+    #[at("/panel-stack")]
+    PanelStack,
+    #[at("/progress-bar")]
+    ProgressBar,
+    #[at("/radio")]
+    Radio,
+    #[at("/slider")]
+    Slider,
+    #[at("/spinner")]
+    Spinner,
+    #[at("/switch")]
+    Switch,
+    #[at("/tabs")]
+    Tabs,
+    #[at("/tag")]
+    Tag,
+    #[at("/textarea")]
+    TextArea,
+    #[at("/text")]
+    Text,
+    #[at("/tree")]
+    Tree,
+    #[at("/")]
+    Home,
+}
+
+fn switch (route: &DocMenu) -> Html {
+    match route {
+        // TODO: redirect home instead of rendering button
+        DocMenu::Button | DocMenu::Home => html!{<ButtonDoc />},
+        DocMenu::ButtonGroup => html!{<ButtonGroupDoc />},
+        DocMenu::Callout => html!{<CalloutDoc />},
+        DocMenu::Card => html!{<CardDoc />},
+        DocMenu::Checkbox => html!{<CheckboxDoc />},
+        DocMenu::Collapse => html!{<CollapseDoc />},
+        DocMenu::ControlGroup => html!{<ControlGroupDoc />},
+        DocMenu::Divider => html!{<DividerDoc />},
+        DocMenu::HtmlSelect => html!{<HtmlSelectDoc />},
+        DocMenu::Icon => html!{<IconDoc />},
+        DocMenu::InputGroup => html!{<InputGroupDoc />},
+        DocMenu::Menu => html!{<MenuDoc />},
+        DocMenu::NumericInput => html!{<NumericInputDoc />},
+        DocMenu::PanelStack => html!{<PanelStackDoc />},
+        DocMenu::ProgressBar => html!{<ProgressBarDoc />},
+        DocMenu::Radio => html!{<RadioDoc />},
+        DocMenu::Slider => html!{<SliderDoc />},
+        DocMenu::Spinner => html!{<SpinnerDoc />},
+        DocMenu::Switch => html!{<SwitchDoc />},
+        DocMenu::Tabs => html!{<TabsDoc />},
+        DocMenu::Tag => html!{<TagDoc />},
+        DocMenu::Text => html!{<TextDoc />},
+        DocMenu::TextArea => html!{<TextAreaDoc />},
+        DocMenu::Tree => html!{<TreeDoc />},
+    }
 }
 
 impl Component for App {
@@ -52,8 +131,9 @@ impl Component for App {
                 .and_then(|x| x.match_media("(prefers-color-scheme: dark)").ok().flatten())
                 .map(|x| x.matches())
                 .unwrap_or(true),
-            link,
-            route_dispatcher: RouteAgentDispatcher::new(),
+            link: ctx.link().clone(),
+            // TODO: don't use global default
+            active: BrowserHistory::default().location().route(),
         }
     }
 
@@ -61,9 +141,11 @@ impl Component for App {
         match msg {
             Msg::ToggleLight => self.dark_theme ^= true,
             Msg::GoToMenu(doc_menu) => {
-                self.route_dispatcher
-                    .send(RouteRequest::ChangeRoute(doc_menu.into()));
-            }
+                if self.active != Some(doc_menu.clone()) {
+                    self.active = Some(doc_menu.clone());
+                    BrowserHistory::default().push(doc_menu);
+                }
+            },
         }
         true
     }
@@ -111,157 +193,209 @@ impl Component for App {
                                 <MenuItem
                                     text={html!(go_to_theme_label)}
                                     onclick={self.link
-                                        .callback(|_| Msg::ToggleLight)}
+                                        .callback(|e: MouseEvent| {e.prevent_default(); Msg::ToggleLight})}
                                     icon={go_to_theme_icon}
                                 />
                                 <MenuItem
                                     text={html!("Button")}
-                                    href={Cow::Borrowed("#button")}
+                                    href="/button"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Button))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Button)})
+                                    }
+                                    active={
+                                        self.active == Some(DocMenu::Button) ||
+                                        self.active == Some(DocMenu::Home)
+                                    }
                                 />
                                 <MenuItem
                                     text={html!("ButtonGroup")}
-                                    href={Cow::Borrowed("#button-group")}
+                                    href="/button-group"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::ButtonGroup))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::ButtonGroup)})
+                                    }
+                                    active={self.active == Some(DocMenu::ButtonGroup)}
                                 />
                                 <MenuItem
                                     text={html!("Callout")}
-                                    href={Cow::Borrowed("#callout")}
+                                    href="/callout"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Callout))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Callout)})
+                                    }
+                                    active={self.active == Some(DocMenu::Callout)}
                                 />
                                 <MenuItem
                                     text={html!("Card")}
-                                    href={Cow::Borrowed("#card")}
+                                    href="/card"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Card))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Card)})
+                                    }
+                                    active={self.active == Some(DocMenu::Card)}
                                 />
                                 <MenuItem
                                     text={html!("Checkbox")}
-                                    href={Cow::Borrowed("#checkbox")}
+                                    href="/checkbox"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Checkbox))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Checkbox)})
+                                    }
+                                    active={self.active == Some(DocMenu::Checkbox)}
                                 />
                                 <MenuItem
                                     text={html!("Collapse")}
-                                    href={Cow::Borrowed("#collapse")}
+                                    href="/collapse"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Collapse))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Collapse)})
+                                    }
+                                    active={self.active == Some(DocMenu::Collapse)}
                                 />
                                 <MenuItem
                                     text={html!("ControlGroup")}
-                                    href={Cow::Borrowed("#control-group")}
+                                    href="/control-group"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::ControlGroup))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::ControlGroup)})
+                                    }
+                                    active={self.active == Some(DocMenu::ControlGroup)}
                                     />
                                 <MenuItem
                                     text={html!("Divider")}
-                                    href={Cow::Borrowed("#divider")}
+                                    href="/divider"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Divider))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Divider)})
+                                    }
+                                    active={self.active == Some(DocMenu::Divider)}
                                 />
                                 <MenuItem
                                     text={html!("HtmlSelect")}
-                                    href={Cow::Borrowed("#html-select")}
+                                    href="/html-select"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::HtmlSelect))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::HtmlSelect)})
+                                    }
+                                    active={self.active == Some(DocMenu::HtmlSelect)}
                                 />
                                 <MenuItem
                                     text={html!("Icon")}
-                                    href={Cow::Borrowed("#icon")}
+                                    href="/icon"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Icon))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Icon)})
+                                    }
+                                    active={self.active == Some(DocMenu::Icon)}
                                 />
                                 <MenuItem
                                     text={html!("InputGroup")}
-                                    href={Cow::Borrowed("#input-group")}
+                                    href="/input-group"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::InputGroup))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::InputGroup)})
+                                    }
+                                    active={self.active == Some(DocMenu::InputGroup)}
                                 />
                                 <MenuItem
                                     text={html!("Menu")}
-                                    href={Cow::Borrowed("#menu")}
+                                    href="/menu"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Menu)})
+                                    }
+                                    active={self.active == Some(DocMenu::Menu)}
                                 />
                                 <MenuItem
                                     text={html!("NumericInput")}
-                                    href={Cow::Borrowed("#numeric-input")}
+                                    href="/numeric-input"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::NumericInput))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::NumericInput)})
+                                    }
+                                    active={self.active == Some(DocMenu::NumericInput)}
                                 />
                                 <MenuItem
                                     text={html!("PanelStack")}
-                                    href={Cow::Borrowed("#panel-stack")}
+                                    href="/panel-stack"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::PanelStack))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::PanelStack)})
+                                    }
+                                    active={self.active == Some(DocMenu::PanelStack)}
                                 />
                                 <MenuItem
                                     text={html!("ProgressBar")}
-                                    href={Cow::Borrowed("#progress-bar")}
+                                    href="/progress-bar"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::ProgressBar))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::ProgressBar)})
+                                    }
+                                    active={self.active == Some(DocMenu::ProgressBar)}
                                 />
                                 <MenuItem
                                     text={html!("Radio")}
-                                    href={Cow::Borrowed("#radio")}
+                                    href="/radio"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Radio))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Radio)})
+                                    }
+                                    active={self.active == Some(DocMenu::Radio)}
                                 />
                                 <MenuItem
                                     text={html!("Slider")}
-                                    href={Cow::Borrowed("#slider")}
-                                    onclick={self.link.callback(|_| Msg::GoToMenu(DocMenu::Slider))
-                                />}
+                                    href="/slider"
+                                    onclick={self.link
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Slider)})
+                                    }
+                                    active={self.active == Some(DocMenu::Slider)}
+                                />
                                 <MenuItem
                                     text={html!("Spinner")}
-                                    href={Cow::Borrowed("#spinner")}
+                                    href="/spinner"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Spinner))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Spinner)})
+                                    }
+                                    active={self.active == Some(DocMenu::Spinner)}
                                 />
                                 <MenuItem
                                     text={html!("Switch")}
-                                    href={Cow::Borrowed("#switch")}
+                                    href="/switch"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Switch))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Switch)})
+                                    }
+                                    active={self.active == Some(DocMenu::Switch)}
                                 />
                                 <MenuItem
                                     text={html!("Tabs")}
-                                    href={Cow::Borrowed("#tabs")}
+                                    href="/tabs"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Tabs))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Tabs)})
+                                    }
+                                    active={self.active == Some(DocMenu::Tabs)}
                                 />
                                 <MenuItem
                                     text={html!("Tag")}
-                                    href={Cow::Borrowed("#tag")}
+                                    href="/tag"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Tag))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Tag)})
+                                    }
+                                    active={self.active == Some(DocMenu::Tag)}
                                 />
                                 <MenuItem
                                     text={html!("Text")}
-                                    href={Cow::Borrowed("#text")}
+                                    href="/text"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Text))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Text)})
+                                    }
+                                    active={self.active == Some(DocMenu::Text)}
                                 />
                                 <MenuItem
                                     text={html!("TextArea")}
-                                    href={Cow::Borrowed("#textarea")}
+                                    href="/textarea"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::TextArea))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::TextArea)})
+                                    }
+                                    active={self.active == Some(DocMenu::TextArea)}
                                 />
                                 <MenuItem
                                     text={html!("Tree")}
-                                    href={Cow::Borrowed("#tree")}
+                                    href="/tree"
                                     onclick={self.link
-                                        .callback(|_| Msg::GoToMenu(DocMenu::Tree))}
+                                        .callback(|e: MouseEvent| { e.prevent_default(); Msg::GoToMenu(DocMenu::Tree)})
+                                    }
+                                    active={self.active == Some(DocMenu::Tree)}
                                 />
                                 // NOTE: thanks to keep this list of <MenuItem> sorted
                                 //       alphabetically (except for the light switch)
                             </Menu>
-                            <div class="docs-nav-sponsors">
-                                <a href={Cow::Borrowed("https://www.netlify.com")}>
+                            <div class={classes!("docs-nav-sponsors")}>
+                                <a href="https://www.netlify.com">
                                     <img
                                         src={netlify_badge}
                                         alt="Deploys by Netlify"
@@ -272,94 +406,13 @@ impl Component for App {
                     </div>
                     <main class={classes!("docs-content-wrapper")} role="main">
                         <div class={classes!("docs-page")}>
-                            <Router<DocMenu, ()>
-                                render=Router::render(|switch: DocMenu| {
-                                    match switch {
-                                        DocMenu::Button | DocMenu::Home => html! (<ButtonDoc />),
-                                        DocMenu::ButtonGroup => html! (<ButtonGroupDoc />),
-                                        DocMenu::Callout => html!(<CalloutDoc />),
-                                        DocMenu::Card => html!(<CardDoc />),
-                                        DocMenu::Checkbox => html!(<CheckboxDoc />),
-                                        DocMenu::Collapse => html!(<CollapseDoc />),
-                                        DocMenu::ControlGroup => html!(<ControlGroupDoc />),
-                                        DocMenu::Divider => html!(<DividerDoc />),
-                                        DocMenu::HtmlSelect => html!(<HtmlSelectDoc />),
-                                        DocMenu::Icon => html!(<IconDoc />),
-                                        DocMenu::InputGroup => html!(<InputGroupDoc />),
-                                        DocMenu::Menu => html!(<MenuDoc />),
-                                        DocMenu::NumericInput => html!(<NumericInputDoc />),
-                                        DocMenu::PanelStack => html!(<PanelStackDoc />),
-                                        DocMenu::ProgressBar => html!(<ProgressBarDoc />),
-                                        DocMenu::Radio => html!(<RadioDoc />),
-                                        DocMenu::Slider => html!(<SliderDoc />),
-                                        DocMenu::Spinner => html!(<SpinnerDoc />),
-                                        DocMenu::Switch => html!(<SwitchDoc />),
-                                        DocMenu::Tabs => html!(<TabsDoc />),
-                                        DocMenu::Tag => html!(<TagDoc />),
-                                        DocMenu::Text => html!(<TextDoc />),
-                                        DocMenu::TextArea => html!(<TextAreaDoc />),
-                                        DocMenu::Tree => html!(<TreeDoc />),
-                                    }
-                                })
-                            />
+                            <BrowserRouter>
+                                <Switch<DocMenu> render={Switch::render(switch)} />
+                            </BrowserRouter>
                         </div>
                     </main>
                 </div>
             </div>
         }
     }
-}
-
-#[derive(Debug, Copy, Clone, Switch)]
-pub enum DocMenu {
-    #[to = "/#button-group"]
-    ButtonGroup,
-    #[to = "/#button"]
-    Button,
-    #[to = "/#callout"]
-    Callout,
-    #[to = "/#card"]
-    Card,
-    #[to = "/#checkbox"]
-    Checkbox,
-    #[to = "/#collapse"]
-    Collapse,
-    #[to = "/#control-group"]
-    ControlGroup,
-    #[to = "/#html-select"]
-    HtmlSelect,
-    #[to = "/#divider"]
-    Divider,
-    #[to = "/#icon"]
-    Icon,
-    #[to = "/#input-group"]
-    InputGroup,
-    #[to = "/#menu"]
-    Menu,
-    #[to = "/#numeric-input"]
-    NumericInput,
-    #[to = "/#panel-stack"]
-    PanelStack,
-    #[to = "/#progress-bar"]
-    ProgressBar,
-    #[to = "/#radio"]
-    Radio,
-    #[to = "/#slider"]
-    Slider,
-    #[to = "/#spinner"]
-    Spinner,
-    #[to = "/#switch"]
-    Switch,
-    #[to = "/#tabs"]
-    Tabs,
-    #[to = "/#tag"]
-    Tag,
-    #[to = "/#textarea"]
-    TextArea,
-    #[to = "/#text"]
-    Text,
-    #[to = "/#tree"]
-    Tree,
-    #[to = "/"]
-    Home,
 }

--- a/yewprint-doc/src/button_group/example.rs
+++ b/yewprint-doc/src/button_group/example.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use yew::prelude::*;
 use yewprint::{Button, ButtonGroup, IconName};
 
@@ -20,12 +19,21 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -35,11 +43,11 @@ impl Component for Example {
                 fill={self.props.fill}
                 large={self.props.large}
                 vertical={self.props.vertical}
-                style={Cow::Borrowed("margin:0;")}
+                style="margin:0;"
             >
-                <Button icon={IconName::Database>{"Queries"}</Button>}
-                <Button icon={IconName::Function>{"Functions"}</Button>}
-                <Button icon={IconName::Cog>{"Options"}</Button>}
+                <Button icon={IconName::Database}>{"Queries"}</Button>
+                <Button icon={IconName::Function}>{"Functions"}</Button>
+                <Button icon={IconName::Cog}>{"Options"}</Button>
             </ButtonGroup>
         }
     }

--- a/yewprint-doc/src/buttons/example.rs
+++ b/yewprint-doc/src/buttons/example.rs
@@ -2,7 +2,7 @@ use yew::prelude::*;
 use yewprint::Button;
 
 pub struct Example {
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     counter: i64,
     props: ExampleProps,
 }
@@ -28,10 +28,10 @@ impl Component for Example {
     type Properties = ExampleProps;
 
     fn create(ctx: &Context<Self>) -> Self {
-        Example {
+        Self {
             counter: 0,
-            link,
-            props,
+            link: ctx.link().clone(),
+            props: ctx.props().clone(),
         }
     }
 
@@ -40,6 +40,15 @@ impl Component for Example {
             Msg::AddOne => self.counter += 1,
         }
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/callout/example.rs
+++ b/yewprint-doc/src/callout/example.rs
@@ -19,12 +19,21 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/callout/mod.rs
+++ b/yewprint-doc/src/callout/mod.rs
@@ -89,6 +89,7 @@ crate::build_example_prop_component! {
                                 (Some(Intent::Warning), "Warning".to_string()),
                                 (Some(Intent::Danger), "Danger".to_string()),
                             ]}
+                            value={self.props.intent}
                             onchange={self.update_props(|props, intent| ExampleProps {
                                 intent,
                                 ..props

--- a/yewprint-doc/src/card/example.rs
+++ b/yewprint-doc/src/card/example.rs
@@ -17,12 +17,21 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/checkbox/example.rs
+++ b/yewprint-doc/src/checkbox/example.rs
@@ -1,8 +1,17 @@
 use yew::prelude::*;
 use yewprint::{Checkbox, Label};
 
+#[derive(Clone, PartialEq)]
+pub struct CheckedState {
+    pub gilard: bool,
+    pub jason: bool,
+    pub antoine: bool,
+}
+
 pub struct Example {
     props: ExampleProps,
+    state: CheckedState,
+    link: html::Scope<Self>,
 }
 
 #[derive(Clone, PartialEq, Properties)]
@@ -12,40 +21,73 @@ pub struct ExampleProps {
     pub large: bool,
 }
 
+pub enum Msg {
+    ToggleGilard,
+    ToggleJason,
+    ToggleAntoine,
+}
+
 impl Component for Example {
-    type Message = ();
+    type Message = Msg;
     type Properties = ExampleProps;
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
+            state: CheckedState {
+                gilard: false,
+                jason: false,
+                antoine: false
+            }
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::ToggleGilard => self.state.gilard = !self.state.gilard,
+            Msg::ToggleJason => self.state.jason = !self.state.jason,
+            Msg::ToggleAntoine => self.state.antoine = !self.state.antoine,
+        }
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
         html! {
             <div>
+
                 <Label>{"Assign responsability"}</Label>
                 <Checkbox
                     disabled={self.props.disabled}
                     inline={self.props.inline}
                     large={self.props.large}
+                    checked={self.state.gilard}
+                    onchange={self.link.callback(|_| Msg::ToggleGilard)}
                     label={html!("Gilad Gray")}
                 />
                 <Checkbox
                     disabled={self.props.disabled}
                     inline={self.props.inline}
                     large={self.props.large}
+                    checked={self.state.jason}
+                    onchange={self.link.callback(|_| Msg::ToggleJason)}
                     label={html!("Jason Killian")}
                 />
                 <Checkbox
                     disabled={self.props.disabled}
                     inline={self.props.inline}
                     large={self.props.large}
+                    checked={self.state.antoine}
+                    onchange={self.link.callback(|_| Msg::ToggleAntoine)}
                     label={html!("Antoine Llorca")}
                 />
             </div>

--- a/yewprint-doc/src/checkbox/mod.rs
+++ b/yewprint-doc/src/checkbox/mod.rs
@@ -39,7 +39,7 @@ impl Component for CheckboxDoc {
 
         html! {
             <div>
-            <H1 class=c{lasses!("docs-title")}>{"Checkbox"}</H1>
+            <H1 class={classes!("docs-title")}>{"Checkbox"}</H1>
             <SourceCodeUrl />
             <ExampleContainer
                 source={source}

--- a/yewprint-doc/src/collapse/example.rs
+++ b/yewprint-doc/src/collapse/example.rs
@@ -2,7 +2,7 @@ use yew::prelude::*;
 use yewprint::{Button, Collapse};
 
 pub struct Example {
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     collapsed: bool,
 }
 
@@ -17,7 +17,7 @@ impl Component for Example {
     fn create(ctx: &Context<Self>) -> Self {
         Example {
             collapsed: true,
-            link,
+            link: ctx.link().clone(),
         }
     }
 

--- a/yewprint-doc/src/collapse/mod.rs
+++ b/yewprint-doc/src/collapse/mod.rs
@@ -11,7 +11,7 @@ impl Component for CollapseDoc {
     type Message = ();
     type Properties = ();
 
-    fn create(ctx: &Context<Self>) -> Self {
+    fn create(_ctx: &Context<Self>) -> Self {
         CollapseDoc
     }
 

--- a/yewprint-doc/src/control_group/example.rs
+++ b/yewprint-doc/src/control_group/example.rs
@@ -3,6 +3,8 @@ use yewprint::{Button, ControlGroup, HtmlSelect, IconName, InputGroup};
 
 pub struct Example {
     props: ExampleProps,
+    link: html::Scope<Self>,
+    selected: Option<Sorting>,
 }
 
 #[derive(Clone, PartialEq, Properties)]
@@ -11,18 +13,36 @@ pub struct ExampleProps {
     pub vertical: bool,
 }
 
+pub enum Msg {
+    Select(Option<Sorting>),
+}
+
 impl Component for Example {
-    type Message = ();
+    type Message = Msg;
     type Properties = ExampleProps;
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
+            selected: None,
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::Select(v) => self.selected = v,
+        }
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -39,8 +59,13 @@ impl Component for Example {
                         (Some(Sorting::PriceAscending), "Price - ascending".to_string()),
                         (Some(Sorting::PriceDescending), "Price - descending".to_string()),
                     ]}
+                    value={self.selected}
+                    onchange={self.link.callback(|x| Msg::Select(x))}
                 />
-                <InputGroup placeholder="Find filters..." />
+                // TODO: onchange
+                <InputGroup
+                    placeholder="Find filters..."
+                />
                 <Button icon={IconName::ArrowRight} />
             </ControlGroup>
         }

--- a/yewprint-doc/src/divider/example.rs
+++ b/yewprint-doc/src/divider/example.rs
@@ -16,12 +16,21 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/html_select/example.rs
+++ b/yewprint-doc/src/html_select/example.rs
@@ -3,7 +3,7 @@ use yewprint::{HtmlSelect, Text};
 
 pub struct Example {
     props: ExampleProps,
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     log_level: LogLevel,
 }
 
@@ -21,15 +21,24 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Example {
-            props,
-            link,
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
             log_level: LogLevel::Info,
         }
     }
 
-    fn update(&mut self, _ctx:  &Context<Self>, msg: Self::Message) -> bool {
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         self.log_level = msg;
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/html_select/mod.rs
+++ b/yewprint-doc/src/html_select/mod.rs
@@ -66,39 +66,39 @@ crate::build_example_prop_component! {
             html! {
                 <div>
                     <H5>{"Props"}</H5>
-                <Switch
-                    onclick={self.update_props(|props, _| ExampleProps {
-                        minimal: !props.minimal,
-                        ..props
-                    })}
-                    checked={self.props.minimal}
-                    label={html!("Minimal")}
-                />
-                <Switch
-                    onclick={self.update_props(|props, _| ExampleProps{
-                        fill: !props.fill,
-                        ..props
-                    })}
-                    checked={self.props.fill}
-                    label={html!("Fill")}
-                />
-                <Switch
-                    onclick={self.update_props(|props, _| ExampleProps {
-                        disabled: !props.disabled,
-                        ..props
-                    })}
-                    checked={self.props.disabled}
-                    label={html!("Disabled")}
-                />
-                <Switch
-                    onclick={self.update_props(|props, _| ExampleProps{
-                        large: !props.large,
-                        ..props
-                    })}
-                    checked={self.props.large}
-                    label={html!("Large")}
-                />
-            </div>
+                    <Switch
+                        onclick={self.update_props(|props, _| ExampleProps {
+                            minimal: !props.minimal,
+                            ..props
+                        })}
+                        checked={self.props.minimal}
+                        label={html!("Minimal")}
+                    />
+                    <Switch
+                        onclick={self.update_props(|props, _| ExampleProps{
+                            fill: !props.fill,
+                            ..props
+                        })}
+                        checked={self.props.fill}
+                        label={html!("Fill")}
+                    />
+                    <Switch
+                        onclick={self.update_props(|props, _| ExampleProps {
+                            disabled: !props.disabled,
+                            ..props
+                        })}
+                        checked={self.props.disabled}
+                        label={html!("Disabled")}
+                    />
+                    <Switch
+                        onclick={self.update_props(|props, _| ExampleProps{
+                            large: !props.large,
+                            ..props
+                        })}
+                        checked={self.props.large}
+                        label={html!("Large")}
+                    />
+                </div>
             }
         }
 }

--- a/yewprint-doc/src/icon/example.rs
+++ b/yewprint-doc/src/icon/example.rs
@@ -7,9 +7,10 @@ impl Component for Example {
     type Message = ();
     type Properties = ();
 
-    fn create(ctx: &Context<Self>) -> Self {
+    fn create(_ctx: &Context<Self>) -> Self {
         Example {}
     }
+
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
     }

--- a/yewprint-doc/src/icon/mod.rs
+++ b/yewprint-doc/src/icon/mod.rs
@@ -11,7 +11,7 @@ impl Component for IconDoc {
     type Message = ();
     type Properties = ();
 
-    fn create(ctx: &Context<Self>) -> Self {
+    fn create(_ctx: &Context<Self>) -> Self {
         IconDoc
     }
 

--- a/yewprint-doc/src/input_group/example.rs
+++ b/yewprint-doc/src/input_group/example.rs
@@ -1,8 +1,9 @@
 use yew::prelude::*;
 use yewprint::{Button, IconName, InputGroup, Tag};
+use web_sys::HtmlInputElement;
 
 pub struct Example {
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     props: ExampleProps,
     histogram_value: String,
     password_value: String,
@@ -21,17 +22,17 @@ pub struct ExampleProps {
 
 pub enum Msg {
     AddHistogramEntry,
-    UpdateHistogram(String),
+    UpdateHistogram(InputEvent),
     AddPasswordEntry,
-    UpdatePassword(String),
+    UpdatePassword(InputEvent),
     AddTagsEntry,
-    UpdateTags(String),
+    UpdateTags(InputEvent),
     Noop,
 }
 
 macro_rules! alert {
     ($($arg:tt)*) => {
-        yew::services::DialogService::alert(&format!(
+        gloo_dialogs::alert(&format!(
             $($arg)*
         ))
     };
@@ -43,8 +44,8 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Example {
-            props,
-            link,
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
             histogram_value: Default::default(),
             password_value: Default::default(),
             password_strength: Default::default(),
@@ -59,25 +60,31 @@ impl Component for Example {
                 self.histogram_value = Default::default();
                 true
             }
-            Msg::UpdateHistogram(value) => {
-                self.histogram_value = value;
+            Msg::UpdateHistogram(event) => {
+                let input = event.target_dyn_into::<HtmlInputElement>();
+                input.map(|input| {
+                    self.histogram_value = input.value();
+                });
                 true
             }
             Msg::AddPasswordEntry => {
                 alert!("You sent: {}", self.password_value);
                 self.password_value = Default::default();
+                self.password_strength = html!();
                 true
             }
-            Msg::UpdatePassword(value) => {
-                self.password_strength = match value.len() {
-                    n if n == 0 => html!(),
-                    n if n < 4 => html!(<Tag>{"weak"}</Tag>),
-                    n if n < 8 => html!(<Tag>{"medium"}</Tag>),
-                    _ => html!(<Tag>{"strong"}</Tag>),
-                };
-
-                self.password_value = value;
-
+            Msg::UpdatePassword(event) => {
+                let input = event.target_dyn_into::<HtmlInputElement>();
+                input.map(|input| {
+                    let value = input.value();
+                    self.password_strength = match value.len() {
+                        n if n == 0 => html!(),
+                        n if n < 4 => html!(<Tag>{"weak"}</Tag>),
+                        n if n < 8 => html!(<Tag>{"medium"}</Tag>),
+                        _ => html!(<Tag>{"strong"}</Tag>),
+                    };
+                    self.password_value = value;
+                });
                 true
             }
             Msg::AddTagsEntry => {
@@ -85,11 +92,23 @@ impl Component for Example {
                 self.tags_value = Default::default();
                 true
             }
-            Msg::UpdateTags(val) => {
-                self.tags_value = val;
+            Msg::UpdateTags(event) => {
+                let input = event.target_dyn_into::<HtmlInputElement>();
+                input.map(|input| {
+                    self.tags_value = input.value();
+                });
                 true
             }
             Msg::Noop => false,
+        }
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
         }
     }
 
@@ -103,9 +122,9 @@ impl Component for Example {
                     round={self.props.round}
                     disabled={self.props.disabled}
                     left_icon={IconName::Filter}
-                    placeholder={"Filter histogram..."}
+                    placeholder="Filter histogram..."
                     value={self.histogram_value.clone()}
-                    oninput={self.link.callback(|e: InputData| Msg::UpdateHistogram(e.value))}
+                    oninput={self.link.callback(|e: InputEvent| Msg::UpdateHistogram(e))}
                     onkeydown={self.link.callback(|e: KeyboardEvent| {
                         if e.key() == "Enter" { Msg::AddHistogramEntry } else { Msg::Noop }
                     })}
@@ -117,19 +136,19 @@ impl Component for Example {
                     round={self.props.round}
                     disabled={self.props.disabled}
                     left_element={self.password_strength.clone()}
-                    placeholder={"Enter your password..."}
+                    placeholder="Enter your password..."
                     value={self.password_value.clone()}
-                    oninput={self.link.callback(|e: InputData| Msg::UpdatePassword(e.value))}
+                    oninput={self.link.callback(|e: InputEvent| Msg::UpdatePassword(e))}
                     onkeydown={self.link.callback(|e: KeyboardEvent| {
                         if e.key() == "Enter" { Msg::AddPasswordEntry } else { Msg::Noop }
                     })}
-                    right_element={html! {
+                    right_element={{html! {
                         <Button
                             icon={IconName::Lock}
-                            minimal={true}
+                            minimal=true
                             disabled={self.props.disabled}
                         />
-                    }}
+                    }}}
                 />
                 <InputGroup
                     fill={self.props.fill}
@@ -137,21 +156,21 @@ impl Component for Example {
                     small={self.props.small}
                     round={self.props.round}
                     disabled={self.props.disabled}
-                    left_icon=IconName::Tag
-                    placeholder={"Find tags"}
+                    left_icon={IconName::Tag}
+                    placeholder="Find tags"
                     value={self.tags_value.clone()}
-                    oninput={self.link.callback(|e: InputData| Msg::UpdateTags(e.value))}
+                    oninput={self.link.callback(|e: InputEvent| Msg::UpdateTags(e))}
                     onkeydown={self.link.callback(|e: KeyboardEvent| {
                         if e.key() == "Enter" { Msg::AddTagsEntry } else { Msg::Noop }
                     })}
-                    right_element=html! {
+                    right_element={{html! {
                         <Tag
-                            minimal=true
-                            round=s{elf.props.round}
+                            minimal={true}
+                            round={self.props.round}
                         >
                             {{10000 / 1.max(self.tags_value.len().pow(2))}}
                         </Tag>
-                    }
+                    }}}
                 />
             </>
         }

--- a/yewprint-doc/src/logo.rs
+++ b/yewprint-doc/src/logo.rs
@@ -15,7 +15,9 @@ impl Component for Logo {
     type Properties = LogoProps;
 
     fn create(ctx: &Context<Self>) -> Self {
-        Self { props }
+        Self {
+            props: ctx.props().clone(),
+        }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
@@ -23,8 +25,8 @@ impl Component for Logo {
     }
 
     fn changed(&mut self, ctx: &Context<Self>) -> bool {
-        if props != self.props {
-            self.props = props;
+        if ctx.props().clone() != self.props {
+            self.props = ctx.props().clone();
             true
         } else {
             false

--- a/yewprint-doc/src/menu/example.rs
+++ b/yewprint-doc/src/menu/example.rs
@@ -1,10 +1,9 @@
 use crate::{DocMenu, Logo};
-use std::borrow::Cow;
 use yew::prelude::*;
 use yewprint::{Icon, IconName, Menu, MenuDivider, MenuItem};
 
 pub struct Example {
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
 }
 
 pub enum Msg {
@@ -16,7 +15,9 @@ impl Component for Example {
     type Properties = ();
 
     fn create(ctx: &Context<Self>) -> Self {
-        Self { link }
+        Self {
+            link: ctx.link().clone(),
+        }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
@@ -29,40 +30,40 @@ impl Component for Example {
                 <Menu>
                     <MenuItem
                         text={html!("Custom SVG icon")}
-                        icon_html={html! {
+                        icon_html={{html! {
                             <Logo class={classes!("custom-icon")} />
-                        }}
+                        }}}
                     />
                     <MenuDivider />
                     <MenuItem
                         icon={IconName::NewTextBox}
-                        text={html!{"New text box"}}
-                        href={Cow::Borrowed("#menu")}
+                        text={html!("New text box")}
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />
                     <MenuItem
                         icon={IconName::NewObject}
-                        text={html!{"New object"}}
-                        href={Cow::Borrowed("#menu")}
+                        text={html!("New object")}
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />
                     <MenuItem
                         icon={IconName::NewLink}
-                        text={html!{"New link"}}
-                        href={Cow::Borrowed("#menu")}
+                        text={html!("New link")}
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />
                     <MenuDivider />
                     <MenuItem
                         icon={IconName::Cog}
-                        text={html!{"Settings"}}
-                        label={html! {
-                            <Icon icon=IconName::Share />
-                        }}
-                        href={Cow::Borrowed("#menu")}
+                        text={html!("Settings")}
+                        label={{html! {
+                            <Icon icon={IconName::Share} />
+                        }}}
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />
@@ -73,7 +74,7 @@ impl Component for Example {
                         icon={IconName::Cut}
                         text={html!("Cut")}
                         label={html!("Ctrl+X")}
-                        href={Cow::Borrowed("#menu")}
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />
@@ -81,7 +82,7 @@ impl Component for Example {
                         icon={IconName::Duplicate}
                         text={html!("Copy")}
                         label={html!("Ctrl+C")}
-                        href={Cow::Borrowed("#menu")
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />
@@ -90,26 +91,26 @@ impl Component for Example {
                         text={html!("Paste")}
                         label={html!("Ctrl+V")}
                         disabled=true
-                    />}
+                    />
                     <MenuDivider title={html!("Text")} />
                     <MenuItem
                         icon={IconName::AlignLeft}
                         text={html!("Alignment")}
-                        href={Cow::Borrowed("#menu")}
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />
                     <MenuItem
                         icon={IconName::Style}
                         text={html!("Style")}
-                        href={Cow::Borrowed("#menu")}
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />
                     <MenuItem
                         icon={IconName::Asterisk}
                         text={html!("Miscellaneous")}
-                        href={Cow::Borrowed("#menu")}
+                        href="#menu"
                         onclick={self.link
                             .callback(|_| Msg::GoToMenu(DocMenu::Menu))}
                     />

--- a/yewprint-doc/src/menu/mod.rs
+++ b/yewprint-doc/src/menu/mod.rs
@@ -11,7 +11,7 @@ impl Component for MenuDoc {
     type Message = ();
     type Properties = ();
 
-    fn create(ctx: &Context<Self>) -> Self {
+    fn create(_ctx: &Context<Self>) -> Self {
         MenuDoc
     }
 

--- a/yewprint-doc/src/numeric_input/example.rs
+++ b/yewprint-doc/src/numeric_input/example.rs
@@ -4,7 +4,7 @@ use yewprint::{Button, Callout, IconName, Intent, NumericInput};
 
 pub struct Example {
     props: ExampleProps,
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     value: i32,
     value_two: i32,
 }
@@ -31,8 +31,8 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Example {
-            props,
-            link,
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
             value: 0,
             value_two: 0,
         }
@@ -54,12 +54,22 @@ impl Component for Example {
         true
     }
 
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
+    }
+
     fn view(&self, _ctx: &Context<Self>) -> Html {
         html! {
             <>
             <NumericInput<i32>
                 disabled={self.props.disabled}
-                fill={self.props.large}
+                fill={self.props.fill}
+                large={self.props.large}
                 value={self.value}
                 bounds={-105..}
                 increment=10

--- a/yewprint-doc/src/panel_stack/example.rs
+++ b/yewprint-doc/src/panel_stack/example.rs
@@ -2,7 +2,7 @@ use yew::prelude::*;
 use yewprint::{Button, Intent, PanelStack, PanelStackState, Text};
 
 pub struct Example {
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     props: ExampleProps,
     state: PanelStackState,
 }
@@ -29,7 +29,7 @@ impl Component for Example {
                 <div>{"Hello World!"}</div>
                 <Button
                     intent={Intent::Primary}
-                    onclick={link.callback(|_| ExampleMessage::OpenPanel2)}
+                    onclick={ctx.link().callback(|_| ExampleMessage::OpenPanel2)}
                 >
                     {"Open panel 2"}
                 </Button>
@@ -42,7 +42,11 @@ impl Component for Example {
         })
         .finish();
 
-        Example { link, props, state }
+        Example {
+            link: ctx.link().clone(),
+            props: ctx.props().clone(),
+            state,
+        }
     }
 
     fn update(&mut self, _ctx:  &Context<Self>, msg: Self::Message) -> bool {
@@ -71,10 +75,20 @@ impl Component for Example {
         }
     }
 
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
+    }
+
     fn view(&self, _ctx: &Context<Self>) -> Html {
         html! {
             <div>
                 <PanelStack
+                    // TODO: this makes it impossible to remove the panel after animation. Should be reference, context, singleton?
                     state={self.state.clone()}
                     onclose={self.link.callback(|_| ExampleMessage::ClosePanel)}
                     class={classes!("docs-panel-stack-example")}
@@ -87,7 +101,7 @@ impl Component for Example {
 // Second panel: a simple counter
 
 pub struct Panel2 {
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     counter: i64,
 }
 
@@ -100,7 +114,10 @@ impl Component for Panel2 {
     type Properties = ();
 
     fn create(ctx: &Context<Self>) -> Self {
-        Panel2 { counter: 0, link }
+        Panel2 {
+            counter: 0,
+            link: ctx.link().clone(),
+        }
     }
 
     fn update(&mut self, _ctx:  &Context<Self>, msg: Self::Message) -> bool {

--- a/yewprint-doc/src/progress_bar/example.rs
+++ b/yewprint-doc/src/progress_bar/example.rs
@@ -18,11 +18,20 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/radio/example.rs
+++ b/yewprint-doc/src/radio/example.rs
@@ -3,7 +3,7 @@ use yewprint::{Label, Radio, RadioGroup};
 
 pub struct Example {
     props: ExampleProps,
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     selected_value: Lunch,
 }
 
@@ -24,9 +24,9 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Example {
-            props,
+            props: ctx.props().clone(),
             selected_value: Lunch::Salad,
-            link,
+            link: ctx.link().clone(),
         }
     }
 
@@ -36,6 +36,15 @@ impl Component for Example {
                 self.selected_value = value;
                 true
             }
+        }
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
         }
     }
 

--- a/yewprint-doc/src/slider/example.rs
+++ b/yewprint-doc/src/slider/example.rs
@@ -7,7 +7,7 @@ pub struct Example {
     float: f64,
     integer: i32,
     log_level: Option<LogLevel>,
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
 }
 
 #[derive(Clone, PartialEq, Properties)]
@@ -29,11 +29,11 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Example {
-            props,
+            props: ctx.props().clone(),
             float: 1.2,
             integer: 30,
             log_level: None,
-            link,
+            link: ctx.link().clone(),
         }
     }
 
@@ -51,6 +51,15 @@ impl Component for Example {
             Msg::Noop => {}
         }
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -83,7 +92,7 @@ impl Component for Example {
                         onchange={self.link.callback(|x| Msg::FloatUpdate(x))}
                     />
                     <Tag
-                        style={Cow::Borrowed("width: 32px; margin-left: 16px")}
+                        style="width: 32px; margin-left: 16px"
                         minimal=true
                         intent={self.props.intent}
                     >

--- a/yewprint-doc/src/slider/mod.rs
+++ b/yewprint-doc/src/slider/mod.rs
@@ -126,6 +126,7 @@ crate::build_example_prop_component! {
                         (Some(Intent::Warning), "Warning".to_string()),
                         (Some(Intent::Danger), "Danger".to_string()),
                     ]}
+                    value={self.props.intent}
                     onchange={self.update_props(|props, intent| ExampleProps {
                         intent,
                         ..props

--- a/yewprint-doc/src/spinner/example.rs
+++ b/yewprint-doc/src/spinner/example.rs
@@ -17,12 +17,21 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/spinner/mod.rs
+++ b/yewprint-doc/src/spinner/mod.rs
@@ -74,6 +74,7 @@ crate::build_example_prop_component! {
                             (Some(Intent::Warning), "Warning".to_string()),
                             (Some(Intent::Danger), "Danger".to_string()),
                         ]}
+                        value={self.props.intent}
                         onchange={self.update_props(|props, intent| ExampleProps {
                             intent,
                             ..props

--- a/yewprint-doc/src/switch/example.rs
+++ b/yewprint-doc/src/switch/example.rs
@@ -18,12 +18,21 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -46,7 +55,7 @@ impl Component for Example {
                     disabled={self.props.disabled}
                     inline={self.props.inline}
                     large={self.props.large}
-                    label={html!{<strong>{"Cooperative"}</strong>}}
+                    label={html!(<strong>{"Cooperative"}</strong>)}
                 />
                 <Switch
                     disabled={self.props.disabled}

--- a/yewprint-doc/src/tabs/example.rs
+++ b/yewprint-doc/src/tabs/example.rs
@@ -2,7 +2,7 @@ use yew::prelude::*;
 use yewprint::{Tab, Tabs};
 
 pub struct Example {
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     props: ExampleProps,
     selected: Civilization,
 }
@@ -19,8 +19,8 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Example {
-            link,
-            props,
+            link: ctx.link().clone(),
+            props: ctx.props().clone(),
             selected: Civilization::Minoan,
         }
     }
@@ -28,6 +28,15 @@ impl Component for Example {
     fn update(&mut self, _ctx:  &Context<Self>, msg: Self::Message) -> bool {
         if self.selected != msg {
             self.selected = msg;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
             true
         } else {
             false

--- a/yewprint-doc/src/tag/example.rs
+++ b/yewprint-doc/src/tag/example.rs
@@ -3,7 +3,7 @@ use yewprint::{IconName, Intent, Tag};
 
 pub struct Example {
     props: ExampleProps,
-    link: &html::Scope<Self>,
+    link: html::Scope<Self>,
     tags: Vec<String>,
 }
 
@@ -35,7 +35,11 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         let tags = ctx.props().initial_tags.clone();
-        Example { props, link, tags }
+        Example {
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
+            tags,
+        }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
@@ -54,18 +58,20 @@ impl Component for Example {
     }
 
     fn changed(&mut self, ctx: &Context<Self>) -> bool {
-        if self.props != props {
+        if self.props != *ctx.props() {
             if self.props.reset_tags != ctx.props().reset_tags {
                 self.tags = ctx.props().initial_tags.clone();
             }
-            self.props = props;
+            self.props = ctx.props().clone();
             true
         } else {
             false
         }
     }
 
-    fn view(&self, _ctx: &Context<Self>) -> Html {
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let props = ctx.props().clone();
+
         self.tags
             .iter()
             .map(|label| {
@@ -78,16 +84,16 @@ impl Component for Example {
                 };
                 html! {
                     <Tag
-                        active={self.props.active}
-                        fill={self.props.fill}
-                        icon={self.props.icon.then(|| IconName::Print)}
-                        intent={self.props.intent}
-                        interactive={self.props.interactive}
-                        large={self.props.large}
-                        minimal={self.props.minimal}
-                        multiline={self.props.multiline}
-                        right_icon={self.props.right_icon.then(|| IconName::Star)}
-                        round={self.props.round}
+                        active={props.active}
+                        fill={props.fill}
+                        icon={props.icon.then(|| IconName::Print)}
+                        intent={props.intent}
+                        interactive={props.interactive}
+                        large={props.large}
+                        minimal={props.minimal}
+                        multiline={props.multiline}
+                        right_icon={props.right_icon.then(|| IconName::Star)}
+                        round={props.round}
                         onremove={remove}
                         onclick={self.link.callback(|_| ExampleMsg::Click)}
                     >

--- a/yewprint-doc/src/tag/mod.rs
+++ b/yewprint-doc/src/tag/mod.rs
@@ -4,7 +4,6 @@ use crate::ExampleContainer;
 use example::*;
 use yew::prelude::*;
 use yewprint::{Button, ButtonGroup, HtmlSelect, IconName, Intent, Switch, H1, H5};
-
 pub struct TagDoc {
     callback: Callback<ExampleProps>,
     state: ExampleProps,
@@ -74,7 +73,7 @@ impl Component for TagDoc {
                         />
                     })}
                 >
-                    <Example with example_props/>
+                    <Example ..example_props/>
                 </ExampleContainer>
             </div>
         }
@@ -180,6 +179,7 @@ crate::build_example_prop_component! {
                                     (Some(Intent::Warning), "Warning".to_string()),
                                     (Some(Intent::Danger), "Danger".to_string()),
                                 ]}
+                                value={self.props.intent}
                                 onchange={self.update_props(|props, intent| ExampleProps {
                                     intent,
                                     ..props
@@ -188,7 +188,7 @@ crate::build_example_prop_component! {
                             <Button
                                 icon={IconName::Refresh}
                                 onclick={self.update_props(|props, _| ExampleProps {
-                                    reset_tags: ctx.props().reset_tags + 1,
+                                    reset_tags: props.reset_tags + 1,
                                     ..props
                                 })}
                             >

--- a/yewprint-doc/src/text/example.rs
+++ b/yewprint-doc/src/text/example.rs
@@ -17,12 +17,21 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/text/mod.rs
+++ b/yewprint-doc/src/text/mod.rs
@@ -4,6 +4,7 @@ use crate::ExampleContainer;
 use example::*;
 use yew::prelude::*;
 use yewprint::{Switch, H1, H5};
+use web_sys::HtmlInputElement;
 
 pub struct TextDoc {
     callback: Callback<ExampleProps>,
@@ -74,20 +75,19 @@ crate::build_example_prop_component! {
                     />
                     <input
                         class="bp3-input"
-                        onchange={self.update_props(|props, e|
-                            match e {
-                                ChangeData::Value(text) => {
-                                    ExampleProps {
-                                        text,
-                                        ..props
-                                    }
-                                },
-                                _ => {
-                                    ExampleProps {
-                                        text: "Hello, world!".to_string(),
-                                        ..props
-                                    }
+                        oninput={self.update_props(|props, e: InputEvent| {
+                            let input = e.target_dyn_into::<HtmlInputElement>();
+                            let mut text = props.text;
+                            input.map(|input| {
+                                text = input.value();
+                                if text.trim() == "" {
+                                    text = "Hello, world!".to_string();
                                 }
+                            });
+                            ExampleProps {
+                                text,
+                                ..props
+                            }
                         })}
                         type="text"
                         value={self.props.text.clone()}

--- a/yewprint-doc/src/text_area/example.rs
+++ b/yewprint-doc/src/text_area/example.rs
@@ -19,12 +19,21 @@ impl Component for Example {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint-doc/src/text_area/mod.rs
+++ b/yewprint-doc/src/text_area/mod.rs
@@ -98,6 +98,7 @@ crate::build_example_prop_component! {
                             (Some(Intent::Warning), "Warning".to_string()),
                             (Some(Intent::Danger), "Danger".to_string()),
                         ]}
+                        value={self.props.intent}
                         onchange={self.update_props(|props, intent| ExampleProps {
                             intent,
                             ..props

--- a/yewprint-doc/src/tree/mod.rs
+++ b/yewprint-doc/src/tree/mod.rs
@@ -11,7 +11,7 @@ impl Component for TreeDoc {
     type Message = ();
     type Properties = ();
 
-    fn create(ctx: &Context<Self>) -> Self {
+    fn create(_ctx: &Context<Self>) -> Self {
         TreeDoc
     }
 

--- a/yewprint-doc/static/index.html
+++ b/yewprint-doc/static/index.html
@@ -49,7 +49,8 @@
 		}
 
 		.docs-nav .bp3-menu-item:hover {
-			background-color: transparent;
+			/* breaks hover on light theme when active */
+			/* background-color: transparent; */
 			font-weight: 600;
 		}
 

--- a/yewprint/Cargo.toml
+++ b/yewprint/Cargo.toml
@@ -20,6 +20,7 @@ tree = ["id_tree"]
 [dependencies]
 web-sys = { version = "0.3", features = ["DomRect", "Element"] }
 yew = "0.19"
+yewtil = { version = "0.4", features = ["pure"] }
 id_tree = { version = "1.7", optional = true }
 wasm-bindgen = "0.2"
 gloo-timers = "0.2.2"

--- a/yewprint/src/button_group.rs
+++ b/yewprint/src/button_group.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use yew::prelude::*;
 
 pub struct ButtonGroup {
@@ -16,7 +15,7 @@ pub struct ButtonGroupProps {
     #[prop_or_default]
     pub large: bool,
     #[prop_or_default]
-    pub style: Option<Cow<'static, str>>,
+    pub style: String,
     #[prop_or_default]
     pub children: html::Children,
     #[prop_or_default]
@@ -29,7 +28,7 @@ impl Component for ButtonGroup {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
@@ -37,7 +36,16 @@ impl Component for ButtonGroup {
         true
     }
 
-    fn view(&self, _ctx: &Context<Self>) -> Html {
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn view(&self, _: &Context<Self>) -> Html {
         html! {
             <div
                 class={classes!(

--- a/yewprint/src/buttons.rs
+++ b/yewprint/src/buttons.rs
@@ -1,5 +1,4 @@
 use crate::{Icon, IconName, Intent, Spinner, ICON_SIZE_LARGE};
-use std::borrow::Cow;
 use yew::prelude::*;
 
 pub struct Button {
@@ -35,7 +34,7 @@ pub struct ButtonProps {
     #[prop_or_default]
     pub class: Classes,
     #[prop_or_default]
-    pub style: Option<Cow<'static, str>>,
+    pub style: String,
     #[prop_or_default]
     pub children: html::Children,
 }
@@ -46,12 +45,23 @@ impl Component for Button {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        let props = ctx.props().clone();
+
+        if self.props != props {
+            self.props = props;
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/callout.rs
+++ b/yewprint/src/callout.rs
@@ -28,12 +28,21 @@ impl Component for Callout {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -64,7 +73,7 @@ impl Component for Callout {
                 }
                 {
                     self.props.title.iter()
-                        .map(|title| html!{<h4 class={"bp3-heading"}>{title}</h4>})
+                        .map(|title| html!{<h4 class="bp3-heading">{title}</h4>})
                         .collect::<Html>()
                 }
                 { self.props.children.clone() }

--- a/yewprint/src/card.rs
+++ b/yewprint/src/card.rs
@@ -24,12 +24,21 @@ impl Component for Card {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/checkbox.rs
+++ b/yewprint/src/checkbox.rs
@@ -28,12 +28,21 @@ impl Component for Checkbox {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/control_group.rs
+++ b/yewprint/src/control_group.rs
@@ -24,12 +24,21 @@ impl Component for ControlGroup {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/divider.rs
+++ b/yewprint/src/divider.rs
@@ -20,12 +20,21 @@ impl Component for Divider {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/html_elements.rs
+++ b/yewprint/src/html_elements.rs
@@ -1,11 +1,10 @@
 use yew::prelude::*;
-use yewtil::{Pure, PureComponent};
 
 macro_rules! build_component {
     ($name:ident, $props_name:ident, $tag:tt, $class:literal) => {
-        pub type $name = Pure<$props_name>;
+        pub type $name = $props_name;
 
-        #[derive(Debug, Clone, PartialEq, yew::prelude::Properties)]
+        #[derive(Debug, Clone, PartialEq, Properties)]
         pub struct $props_name {
             #[prop_or_default]
             pub class: Classes,
@@ -18,7 +17,10 @@ macro_rules! build_component {
             type Properties = Self;
 
             fn create(_ctx: &Context<Self>) -> Self {
-                Self
+                Self {
+                    children: _ctx.props().children.clone(),
+                    class: _ctx.props().class.clone(),
+                }
             }
 
             fn view(&self, _ctx: &yew::Context<Self>) -> Html {

--- a/yewprint/src/html_select.rs
+++ b/yewprint/src/html_select.rs
@@ -1,5 +1,6 @@
 use crate::{Icon, IconName};
 use yew::prelude::*;
+use web_sys::HtmlSelectElement;
 
 pub struct HtmlSelect<T: Clone + PartialEq + 'static> {
     props: HtmlSelectProps<T>,
@@ -35,23 +36,27 @@ impl<T: Clone + PartialEq + 'static> Component for HtmlSelect<T> {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
-            link: *ctx.link(),
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
-        let i = if let Event::Select(select) = msg {
-            select.selected_index()
-        } else {
-            unreachable!("unexpected ChangeData variant: {:?}", msg);
-        };
-        if i >= 0 {
-            let i = i as usize;
-            let variant = self.props.options[i].0.clone();
-            self.props.onchange.emit(variant);
-        }
+        let input = msg.target_dyn_into::<HtmlSelectElement>();
+        input.map(|input| {
+            let i = input.selected_index() as usize;
+            self.props.onchange.emit(self.props.options[i].0.clone());
+        });
         false
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -90,7 +95,6 @@ impl<T: Clone + PartialEq + 'static> Component for HtmlSelect<T> {
                     disabled={self.props.disabled}
                     onchange={self.link.callback(|x| x)}
                     title={self.props.title.clone()}
-                    value={"".to_string()}
                 >
                     {option_children}
                 </select>

--- a/yewprint/src/icon.rs
+++ b/yewprint/src/icon.rs
@@ -39,12 +39,21 @@ impl Component for Icon {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/input_group.rs
+++ b/yewprint/src/input_group.rs
@@ -93,8 +93,8 @@ impl Component for InputGroup {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
-            link: *ctx.link(),
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
             left_element_ref: Default::default(),
             left_element_width: Default::default(),
             right_element_ref: Default::default(),
@@ -102,8 +102,17 @@ impl Component for InputGroup {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
+    fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -179,7 +188,7 @@ impl Component for InputGroup {
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, _ctx: &Context<Self>, _first_render: bool) {
         let left_old_value = self.left_element_width.take();
         self.left_element_width = self
             .left_element_ref

--- a/yewprint/src/menu.rs
+++ b/yewprint/src/menu.rs
@@ -1,5 +1,4 @@
 use crate::{Icon, IconName, Intent, H6};
-use std::borrow::Cow;
 use yew::prelude::*;
 
 pub struct Menu {
@@ -23,12 +22,21 @@ impl Component for Menu {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -64,7 +72,7 @@ pub struct MenuItemProps {
     #[prop_or_default]
     pub disabled: bool,
     #[prop_or_default]
-    pub href: Option<Cow<'static, str>>,
+    pub href: String,
     #[prop_or_default]
     pub label: Option<yew::virtual_dom::VNode>,
     #[prop_or_default]
@@ -88,12 +96,21 @@ impl Component for MenuItem {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -108,7 +125,7 @@ impl Component for MenuItem {
                             .or_else(|| self.props.active.then(|| Intent::Primary)),
                         self.props.class.clone(),
                     )}
-                    href={(!self.props.disabled).then(|| self.props.href.clone()).flatten()}
+                    href={(!self.props.disabled).then(|| self.props.href.clone())}
                     tabIndex={(!self.props.disabled).then(|| "0")}
                     onclick={(!self.props.disabled).then(|| self.props.onclick.clone())}
                 >
@@ -166,7 +183,7 @@ impl Component for MenuDivider {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 

--- a/yewprint/src/panel_stack.rs
+++ b/yewprint/src/panel_stack.rs
@@ -1,11 +1,11 @@
 use crate::{Button, IconName};
 use gloo_timers::callback::Timeout;
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
-use std::time::Duration;
 use yew::prelude::*;
+
+const EXIT_TIMEOUT: u32 = 400;
 
 pub struct PanelBuilder<F: Fn(Option<Html>, I) -> O, I, O> {
     title: Option<Html>,
@@ -60,10 +60,13 @@ impl PanelStackState {
     }
 
     pub fn close_panel(&mut self) -> bool {
-        let opened_panels = self.opened_panels.borrow();
+        let mut opened_panels = self.opened_panels.borrow_mut();
         if opened_panels.len() > 1 {
             self.version = self.version.wrapping_add(1);
             self.action.replace(StateAction::Pop);
+            // TODO: animation when closing does not work because state is a clone
+            // this should be done after defering the animation
+            opened_panels.pop();
             true
         } else {
             false
@@ -121,7 +124,7 @@ impl From<StateAction> for Classes {
 pub struct PanelStack {
     timeout_task: Option<Timeout>,
     props: PanelStackProps,
-    link: html::Scope<Self>,
+    // link: html::Scope<Self>,
 }
 
 #[derive(Debug, Clone, PartialEq, Properties)]
@@ -144,17 +147,27 @@ impl Component for PanelStack {
     fn create(ctx: &Context<Self>) -> Self {
         Self {
             timeout_task: None,
-            props: *ctx.props(),
-            link: *ctx.link(),
+            props: ctx.props().clone(),
+            // link: ctx.link().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             PanelStackMessage::PopPanel => {
+                // TODO: this does not work because we have a copy of the state
                 self.props.state.opened_panels.borrow_mut().pop();
                 true
             }
+        }
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
         }
     }
 
@@ -162,7 +175,9 @@ impl Component for PanelStack {
         let opened_panels = self.props.state.opened_panels.borrow();
         let action = self.props.state.action;
         let last = match action {
-            Some(StateAction::Pop) => opened_panels.len() - 2,
+            // TODO: this does not work because we have a copy of the state
+            // should be -2 while animating and then change back to -1
+            // Some(StateAction::Pop) => opened_panels.len() - 2,
             _ => opened_panels.len() - 1,
         };
 
@@ -179,26 +194,27 @@ impl Component for PanelStack {
                     .iter()
                     .enumerate()
                     .rev()
-                    .map(|(i, (title, content))| html! {
-                        <Panel
-                            title={title.clone()}
-                            animation={
-                                match action {
-                                    _ if i == last => Animation::EnterStart,
-                                    Some(StateAction::Push) if i == last - 1 =>
-                                        Animation::ExitStart,
-                                    Some(StateAction::Pop) if i == last + 1 =>
-                                        Animation::ExitStart,
-                                    _ => Animation::Exited,
+                    .map(|(i, (title, content))| {
+                        let prev_title = if i > 0 { opened_panels[i - 1].0.clone().unwrap() } else { html!{} };
+
+                        html! {
+                            <Panel
+                                title={title.clone()}
+                                prev_title={prev_title}
+                                animation={
+                                    match action {
+                                        Some(StateAction::Push) if i == last - 1 => Animation::ExitStart,
+                                        Some(StateAction::Pop) if i == last + 1 => Animation::ExitStart,
+                                        _ if i == last => Animation::EnterStart,
+                                        _ => Animation::Exited,
+                                    }
                                 }
-                            }
-                            onclose={(i > 0).then(|| self.props.onclose.clone()).flatten()}
-                            key={i}
-                        >
-                            // TODO the state of content doesn't seem to be kept when re-opening
-                            //      a panel using the same components
-                            {content.clone()}
-                        </Panel>
+                                onclose={(i > 0).then(|| self.props.onclose.clone()).flatten()}
+                                key={i}
+                            >
+                                {content.clone()}
+                            </Panel>
+                        }
                     })
                     .collect::<Html>()
             }
@@ -206,11 +222,15 @@ impl Component for PanelStack {
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
-        if self.props.state.action.take() == Some(StateAction::Pop) {
+    fn rendered(&mut self, ctx: &Context<Self>, _first_render: bool) {
+        if self.props.state.action.clone() == Some(StateAction::Pop) {
+            let link = ctx.link().clone();
+            let callback = move || {
+                link.callback(|_: String| PanelStackMessage::PopPanel);
+            };
             self.timeout_task.replace(Timeout::new(
-                Duration::from_millis(400),
-                self.link.callback(|_| PanelStackMessage::PopPanel),
+                400,
+                callback,
             ));
         }
     }
@@ -226,6 +246,7 @@ struct Panel {
 #[derive(Debug, Clone, PartialEq, Properties)]
 struct PanelProps {
     title: Option<Html>,
+    prev_title: Option<Html>,
     animation: Animation,
     onclose: Option<Callback<()>>,
     children: Children,
@@ -244,8 +265,8 @@ impl Component for Panel {
         Self {
             animation: ctx.props().animation,
             timeout_task: None,
-            props: *ctx.props(),
-            link: *ctx.link(),
+            props: ctx.props().clone(),
+            link: ctx.link().clone(),
         }
     }
 
@@ -253,18 +274,71 @@ impl Component for Panel {
         match msg {
             PanelMessage::UpdateAnimation(animation) => {
                 self.animation = animation;
+                match animation {
+                    Animation::EnterStart => {
+                        let link = self.link.clone();
+                        self.timeout_task.replace(Timeout::new(
+                            0,
+                            move || {
+                                link.send_message(PanelMessage::UpdateAnimation(Animation::Entering));
+                            },
+                        ));
+                    }
+                    Animation::Entering => {
+                        let link = self.link.clone();
+                        self.timeout_task.replace(Timeout::new(
+                            400,
+                            move || {
+                                link.send_message(PanelMessage::UpdateAnimation(Animation::Entered));
+                            },
+                        ));
+                    }
+                    Animation::Entered => {}
+                    Animation::ExitStart => {
+                        let link = self.link.clone();
+                        self.timeout_task.replace(Timeout::new(
+                            0,
+                            move || {
+                                link.send_message(PanelMessage::UpdateAnimation(Animation::Exiting));
+                            },
+                        ));
+                    }
+                    Animation::Exiting => {
+                        let link = self.link.clone();
+                        self.timeout_task.replace(Timeout::new(
+                            EXIT_TIMEOUT,
+                            move || {
+                                link.send_message(PanelMessage::UpdateAnimation(Animation::Exited));
+                            },
+                        ));
+                    }
+                    Animation::Exited => {}
+                };
                 true
             }
         }
     }
 
     fn changed(&mut self, ctx: &Context<Self>) -> bool {
-        if self.props != ctx.props() {
-            self.animation = ctx.props().animation;
-            self.props = ctx.props();
+        if self.props.animation != ctx.props().animation {
+            match ctx.props().animation {
+                Animation::ExitStart | Animation::EnterStart | Animation::Entered | Animation::Exited => {
+                    self.link.send_message(PanelMessage::UpdateAnimation(ctx.props().animation))
+                },
+                _ => {},
+            };
+        }
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
             true
         } else {
             false
+        }
+    }
+
+    fn rendered(&mut self, _ctx: &Context<Self>, first_render: bool) {
+        if first_render {
+            self.link.send_message(PanelMessage::UpdateAnimation(self.animation));
         }
     }
 
@@ -289,14 +363,13 @@ impl Component for Panel {
             html! {
                 <Button
                     class={classes!("bp3-panel-stack-header-back")}
-                    style={Cow::Borrowed("padding-right:0")}
+                    style="padding-right:0"
                     icon={IconName::ChevronLeft}
-                    minimal={true}
-                    small={true}
+                    minimal=true
+                    small=true
                     onclick={onclose.reform(|_| ())}
                 >
-                    // TODO: I get a lot of "VComp is not mounted" if I try to use the title
-                    //       of the previous panel
+                    {self.props.prev_title.clone().unwrap_or_default()}
                 </Button>
             }
         });
@@ -310,41 +383,6 @@ impl Component for Panel {
                 </div>
                 {for self.props.children.iter()}
             </div>
-        }
-    }
-
-    fn rendered(&mut self, _first_render: bool) {
-        match self.animation {
-            Animation::EnterStart => {
-                self.timeout_task.replace(Timeout::new(
-                    Duration::from_millis(0),
-                    self.link
-                        .callback(|_| PanelMessage::UpdateAnimation(Animation::Entering)),
-                ));
-            }
-            Animation::Entering => {
-                self.timeout_task.replace(Timeout::new(
-                    Duration::from_millis(400),
-                    self.link
-                        .callback(|_| PanelMessage::UpdateAnimation(Animation::Entered)),
-                ));
-            }
-            Animation::Entered => {}
-            Animation::ExitStart => {
-                self.timeout_task.replace(Timeout::new(
-                    Duration::from_millis(0),
-                    self.link
-                        .callback(|_| PanelMessage::UpdateAnimation(Animation::Exiting)),
-                ));
-            }
-            Animation::Exiting => {
-                self.timeout_task.replace(Timeout::new(
-                    Duration::from_millis(400),
-                    self.link
-                        .callback(|_| PanelMessage::UpdateAnimation(Animation::Exited)),
-                ));
-            }
-            Animation::Exited => {}
         }
     }
 }

--- a/yewprint/src/progress_bar.rs
+++ b/yewprint/src/progress_bar.rs
@@ -25,12 +25,21 @@ impl Component for ProgressBar {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/radio.rs
+++ b/yewprint/src/radio.rs
@@ -30,12 +30,21 @@ impl Component for Radio {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/radio_group.rs
+++ b/yewprint/src/radio_group.rs
@@ -30,12 +30,21 @@ impl<T: Clone + PartialEq + 'static> Component for RadioGroup<T> {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/slider.rs
+++ b/yewprint/src/slider.rs
@@ -46,20 +46,20 @@ impl<T: Clone + PartialEq + 'static> Component for Slider<T> {
         let mouse_move = {
             let link = ctx.link().clone();
             Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
-                ctx.link().send_message(Msg::Mouse(event));
+                link.send_message(Msg::Mouse(event));
             }) as Box<dyn FnMut(_)>)
         };
         let mouse_up = {
             let link = ctx.link().clone();
             Closure::wrap(Box::new(move |_event: web_sys::MouseEvent| {
-                ctx.link().send_message(Msg::StopChange);
+                link.send_message(Msg::StopChange);
             }) as Box<dyn FnMut(_)>)
         };
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
             mouse_move,
             mouse_up,
-            link: *ctx.link(),
+            link: ctx.link().clone(),
             handle_ref: NodeRef::default(),
             track_ref: NodeRef::default(),
             is_moving: false,
@@ -177,6 +177,15 @@ impl<T: Clone + PartialEq + 'static> Component for Slider<T> {
         }
     }
 
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
+    }
+
     fn view(&self, _ctx: &Context<Self>) -> Html {
         let value_index = self
             .props
@@ -208,7 +217,7 @@ impl<T: Clone + PartialEq + 'static> Component for Slider<T> {
             html! {
                 <div
                     class={classes!("bp3-slider-label")}
-                    style={"left: 50%;"}
+                    style="left: 50%;"
                 >
                     {label}
                 </div>
@@ -346,7 +355,7 @@ impl<T: Clone + PartialEq + 'static> Component for Slider<T> {
         }
     }
 
-    fn rendered(&mut self, _: bool) {
+    fn rendered(&mut self, _ctx: &Context<Self>, _: bool) {
         if self.focus_handle {
             if let Some(element) = self.handle_ref.cast::<web_sys::HtmlElement>() {
                 let _ = element.focus();

--- a/yewprint/src/spinner.rs
+++ b/yewprint/src/spinner.rs
@@ -32,12 +32,21 @@ impl Component for Spinner {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/switch.rs
+++ b/yewprint/src/switch.rs
@@ -28,12 +28,21 @@ impl Component for Switch {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -48,17 +57,17 @@ impl Component for Switch {
                     self.props.class.clone(),
                 )}
             >
-            <input
-                type="checkbox"
-                checked={self.props.checked}
-                onclick={self.props.onclick.clone()}
-                disabled={self.props.disabled}
-            />
-            <span
-                class={classes!("bp3-control-indicator")}
-            >
-            </span>
-            {self.props.label.clone()}
+                <input
+                    type="checkbox"
+                    checked={self.props.checked}
+                    onclick={self.props.onclick.clone()}
+                    disabled={self.props.disabled}
+                />
+                <span
+                    class={classes!("bp3-control-indicator")}
+                >
+                </span>
+                {self.props.label.clone()}
             </label>
         }
     }

--- a/yewprint/src/tabs.rs
+++ b/yewprint/src/tabs.rs
@@ -48,7 +48,7 @@ impl<T: Clone + PartialEq + Hash + 'static> Component for Tabs<T> {
             .collect::<HashMap<_, _>>();
 
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
             tab_refs,
             indicator_ref: Default::default(),
         }
@@ -56,6 +56,15 @@ impl<T: Clone + PartialEq + Hash + 'static> Component for Tabs<T> {
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {
@@ -162,7 +171,7 @@ impl<T: Clone + PartialEq + Hash + 'static> Component for Tabs<T> {
         }
     }
 
-    fn rendered(&mut self, _first_render: bool) {
+    fn rendered(&mut self, _ctx: &Context<Self>, _first_render: bool) {
         if self.props.animate {
             let mut hasher = DefaultHasher::new();
             self.props.selected_tab_id.hash(&mut hasher);

--- a/yewprint/src/tag.rs
+++ b/yewprint/src/tag.rs
@@ -1,5 +1,4 @@
 use crate::{if_html, Icon, IconName, Intent, Text};
-use std::borrow::Cow;
 use yew::prelude::*;
 
 pub struct Tag {
@@ -36,11 +35,11 @@ pub struct TagProps {
     #[prop_or_default]
     pub round: bool,
     #[prop_or_default]
-    pub title: Option<Cow<'static, str>>,
+    pub title: String,
     #[prop_or_default]
     pub class: Classes,
     #[prop_or_default]
-    pub style: Option<Cow<'static, str>>,
+    pub style: String,
 }
 
 impl Component for Tag {
@@ -49,12 +48,21 @@ impl Component for Tag {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/text.rs
+++ b/yewprint/src/text.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use yew::prelude::*;
 
 pub struct Text {
@@ -17,9 +16,9 @@ pub struct TextProps {
     #[prop_or_default]
     pub inline: bool,
     #[prop_or_default]
-    pub title: Option<Cow<'static, str>>,
+    pub title: String,
     #[prop_or_default]
-    pub style: Option<Cow<'static, str>>,
+    pub style: String,
 }
 
 impl Component for Text {
@@ -28,12 +27,21 @@ impl Component for Text {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/text_area.rs
+++ b/yewprint/src/text_area.rs
@@ -31,12 +31,21 @@ impl Component for TextArea {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
         true
+    }
+
+    fn changed(&mut self, ctx: &Context<Self>) -> bool {
+        if self.props != *ctx.props() {
+            self.props = ctx.props().clone();
+            true
+        } else {
+            false
+        }
     }
 
     fn view(&self, _ctx: &Context<Self>) -> Html {

--- a/yewprint/src/tree.rs
+++ b/yewprint/src/tree.rs
@@ -114,7 +114,7 @@ impl<T: Clone + PartialEq + 'static> Component for Tree<T> {
 
     fn create(ctx: &Context<Self>) -> Self {
         Self {
-            props: *ctx.props(),
+            props: ctx.props().clone(),
             previous_expanded_state: Default::default(),
         }
     }
@@ -255,7 +255,7 @@ impl Component for TreeNode {
         TreeNode {
             handler_caret_click: ctx.link().callback(TreeNodeMessage::CaretClick),
             handler_click: ctx.link().callback(TreeNodeMessage::Click),
-            props: *ctx.props(),
+            props: ctx.props().clone(),
         }
     }
 
@@ -288,7 +288,7 @@ impl Component for TreeNode {
 
     fn changed(&mut self, ctx: &Context<Self>) -> bool {
         if self.props != *ctx.props() {
-            self.props = *ctx.props();
+            self.props = ctx.props().clone();
             true
         } else {
             false


### PR DESCRIPTION
Hey! I'm trying to learn rust and started by making your update work for me. Maybe some changes can be useful to you, and maybe some are pretty bad. Please take a look and use what you can :P

Some notes on what you will find:
* every component works (yey!)
* active state in menu
* every "props" switch works and updates the component correctly (thats the reason for all the "changed" methods everywhere)
* fixed some global replaces that went sideways xD
* panel_stack "works" and keeps prev state correctly ... there is a problem I think is due to cloning the state I could not solve. Also has the prev tab title on the back button that was not working as per a comment
* tree expands properly instead of computing height late when first loading children
* ads yewtils back (would not work without it, at all ... maybe my mac is dumb)
* fixed on change "I only allow a single character" input behaviour on docs
* optimization problems for sure ... as stated, just learning ;) ... please let me know what I did wrong, why, and what the proper way is when you see something :)